### PR TITLE
chore: update eslint rule no floating promises

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,16 +1,16 @@
 const namingConvention = () => {
 	// prettier-ignore
 	return [
-		{ selector: ['default'], 								 format: null,           modifiers: ['public'],    leadingUnderscore: 'forbid' },
-		{ selector: ['default'], 								 format: ['camelCase'],  modifiers: ['protected'], leadingUnderscore: 'require' },
-		{ selector: ['default'], 								 format: ['camelCase'],  modifiers: ['private'],   prefix: ['__'] },
-		{ selector: ['accessor'], 							 format: ['camelCase'],  modifiers: ['public'],    leadingUnderscore: 'forbid' },
-		{ selector: ['accessor'], 							 format: ['camelCase'],  modifiers: ['protected'], leadingUnderscore: 'require' },
-		{ selector: ['accessor'], 							 format: ['camelCase'],  modifiers: ['private'],   prefix: ['__'] },
-		{ selector: ['enum'], 									 format: ['PascalCase'] },
-		{ selector: ['enumMember'], 						 format: ['UPPER_CASE'] },
+		{ selector: ['default'], format: null, modifiers: ['public'], leadingUnderscore: 'forbid' },
+		{ selector: ['default'], format: ['camelCase'], modifiers: ['protected'], leadingUnderscore: 'require' },
+		{ selector: ['default'], format: ['camelCase'], modifiers: ['private'], prefix: ['__'] },
+		{ selector: ['accessor'], format: ['camelCase'], modifiers: ['public'], leadingUnderscore: 'forbid' },
+		{ selector: ['accessor'], format: ['camelCase'], modifiers: ['protected'], leadingUnderscore: 'require' },
+		{ selector: ['accessor'], format: ['camelCase'], modifiers: ['private'], prefix: ['__'] },
+		{ selector: ['enum'], format: ['PascalCase'] },
+		{ selector: ['enumMember'], format: ['UPPER_CASE'] },
 		{ selector: ['classMethod', 'accessor'], format: ['PascalCase'], modifiers: ['public', 'static'] },
-		{ selector: ['classProperty'], 					 format: ['UPPER_CASE'], modifiers: ['public', 'static'] },
+		{ selector: ['classProperty'], format: ['UPPER_CASE'], modifiers: ['public', 'static'] },
 	]
 }
 
@@ -20,7 +20,7 @@ module.exports = {
 		es6: true,
 		'jest/globals': true,
 		node: true,
-		jest: true
+		jest: true,
 	},
 	settings: {
 		'import/resolver': {
@@ -47,8 +47,9 @@ module.exports = {
 	},
 	plugins: ['@typescript-eslint', 'eslint-plugin-import', 'import', 'no-only-tests', 'no-loops', 'jest', 'sort-keys-fix'],
 	rules: {
-		// TODO TEMP DISABLE
-		'@typescript-eslint/no-explicit-any':'warn',
+		'@typescript-eslint/no-floating-promises': ['error'],
+		// TODO TEMP DISABLED
+		'@typescript-eslint/no-explicit-any': 'warn',
 		// ESLINT
 		// 'no-restricted-imports': [
 		// 	'error',

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,9 +19,9 @@
 				"@babel/preset-env": "7.24.4",
 				"@babel/preset-typescript": "7.24.1",
 				"@beecode/msh-test-contractor": "0.3.9",
-				"@commitlint/cli": "19.2.1",
-				"@commitlint/config-conventional": "19.1.0",
-				"@commitlint/prompt": "19.2.0",
+				"@commitlint/cli": "19.2.2",
+				"@commitlint/config-conventional": "19.2.2",
+				"@commitlint/prompt": "19.2.2",
 				"@jest/globals": "29.7.0",
 				"@semantic-release/changelog": "6.0.3",
 				"@semantic-release/commit-analyzer": "12.0.0",
@@ -52,7 +52,7 @@
 				"markdown-toc": "1.2.0",
 				"prettier": "3.2.5",
 				"rimraf": "5.0.5",
-				"semantic-release": "23.0.7",
+				"semantic-release": "23.0.8",
 				"source-map-support": "0.5.21",
 				"ts-cleaner": "1.0.5",
 				"ts-jest": "29.1.2",
@@ -61,7 +61,7 @@
 				"tsc-watch": "6.2.0",
 				"typedoc": "0.25.13",
 				"typedoc-plugin-markdown": "3.17.1",
-				"typescript": "5.4.4"
+				"typescript": "5.4.5"
 			},
 			"engines": {
 				"node": ">=14",
@@ -2152,13 +2152,13 @@
 			}
 		},
 		"node_modules/@commitlint/cli": {
-			"version": "19.2.1",
-			"resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-19.2.1.tgz",
-			"integrity": "sha512-cbkYUJsLqRomccNxvoJTyv5yn0bSy05BBizVyIcLACkRbVUqYorC351Diw/XFSWC/GtpwiwT2eOvQgFZa374bg==",
+			"version": "19.2.2",
+			"resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-19.2.2.tgz",
+			"integrity": "sha512-P8cbOHfg2PQRzfICLSrzUVOCVMqjEZ8Hlth6mtJ4yOEjT47Q5PbIGymgX3rLVylNw+3IAT2Djn9IJ2wHbXFzBg==",
 			"dev": true,
 			"dependencies": {
 				"@commitlint/format": "^19.0.3",
-				"@commitlint/lint": "^19.1.0",
+				"@commitlint/lint": "^19.2.2",
 				"@commitlint/load": "^19.2.0",
 				"@commitlint/read": "^19.2.1",
 				"@commitlint/types": "^19.0.3",
@@ -2173,9 +2173,9 @@
 			}
 		},
 		"node_modules/@commitlint/config-conventional": {
-			"version": "19.1.0",
-			"resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-19.1.0.tgz",
-			"integrity": "sha512-KIKD2xrp6Uuk+dcZVj3++MlzIr/Su6zLE8crEDQCZNvWHNQSeeGbzOlNtsR32TUy6H3JbP7nWgduAHCaiGQ6EA==",
+			"version": "19.2.2",
+			"resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-19.2.2.tgz",
+			"integrity": "sha512-mLXjsxUVLYEGgzbxbxicGPggDuyWNkf25Ht23owXIH+zV2pv1eJuzLK3t1gDY5Gp6pxdE60jZnWUY5cvgL3ufw==",
 			"dev": true,
 			"dependencies": {
 				"@commitlint/types": "^19.0.3",
@@ -2238,9 +2238,9 @@
 			}
 		},
 		"node_modules/@commitlint/is-ignored": {
-			"version": "19.0.3",
-			"resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-19.0.3.tgz",
-			"integrity": "sha512-MqDrxJaRSVSzCbPsV6iOKG/Lt52Y+PVwFVexqImmYYFhe51iVJjK2hRhOG2jUAGiUHk4jpdFr0cZPzcBkSzXDQ==",
+			"version": "19.2.2",
+			"resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-19.2.2.tgz",
+			"integrity": "sha512-eNX54oXMVxncORywF4ZPFtJoBm3Tvp111tg1xf4zWXGfhBPKpfKG6R+G3G4v5CPlRROXpAOpQ3HMhA9n1Tck1g==",
 			"dev": true,
 			"dependencies": {
 				"@commitlint/types": "^19.0.3",
@@ -2251,12 +2251,12 @@
 			}
 		},
 		"node_modules/@commitlint/lint": {
-			"version": "19.1.0",
-			"resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-19.1.0.tgz",
-			"integrity": "sha512-ESjaBmL/9cxm+eePyEr6SFlBUIYlYpI80n+Ltm7IA3MAcrmiP05UMhJdAD66sO8jvo8O4xdGn/1Mt2G5VzfZKw==",
+			"version": "19.2.2",
+			"resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-19.2.2.tgz",
+			"integrity": "sha512-xrzMmz4JqwGyKQKTpFzlN0dx0TAiT7Ran1fqEBgEmEj+PU98crOFtysJgY+QdeSagx6EDRigQIXJVnfrI0ratA==",
 			"dev": true,
 			"dependencies": {
-				"@commitlint/is-ignored": "^19.0.3",
+				"@commitlint/is-ignored": "^19.2.2",
 				"@commitlint/parse": "^19.0.3",
 				"@commitlint/rules": "^19.0.3",
 				"@commitlint/types": "^19.0.3"
@@ -2310,9 +2310,9 @@
 			}
 		},
 		"node_modules/@commitlint/prompt": {
-			"version": "19.2.0",
-			"resolved": "https://registry.npmjs.org/@commitlint/prompt/-/prompt-19.2.0.tgz",
-			"integrity": "sha512-bhPftma1IVQP5Y8St0ZssDMi1WJFju6Oz1lKZiQauEbCcHzQjRk3OHygGvNt8EXvvDTETV1jncPOjErgYSQTbQ==",
+			"version": "19.2.2",
+			"resolved": "https://registry.npmjs.org/@commitlint/prompt/-/prompt-19.2.2.tgz",
+			"integrity": "sha512-ib+5XYws/g4VkP+4IkfH+kTJRbiInPMaq9vjPzfgQvBR3o7KWEQBk4P6ZsZK7VdGANcNXTKo667FNsfyQLPZgg==",
 			"dev": true,
 			"dependencies": {
 				"@commitlint/ensure": "^19.0.3",
@@ -17397,6 +17397,35 @@
 			"integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
 			"dev": true
 		},
+		"node_modules/read-package-up": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-11.0.0.tgz",
+			"integrity": "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==",
+			"dev": true,
+			"dependencies": {
+				"find-up-simple": "^1.0.0",
+				"read-pkg": "^9.0.0",
+				"type-fest": "^4.6.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/read-package-up/node_modules/type-fest": {
+			"version": "4.15.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.15.0.tgz",
+			"integrity": "sha512-tB9lu0pQpX5KJq54g+oHOLumOx+pMep4RaM6liXh2PKmVRFF+/vAtUP0ZaJ0kOySfVNjF6doBWPHhBhISKdlIA==",
+			"dev": true,
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/read-pkg": {
 			"version": "9.0.1",
 			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
@@ -17962,9 +17991,9 @@
 			"dev": true
 		},
 		"node_modules/semantic-release": {
-			"version": "23.0.7",
-			"resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-23.0.7.tgz",
-			"integrity": "sha512-PFxXQE57zrYiCbWKkdsVUF08s0SifEw3WhDhrN47ZEUWQiLl21FI9Dg/H8g7i/lPx0IkF6u7PjJbgxPceXKBeg==",
+			"version": "23.0.8",
+			"resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-23.0.8.tgz",
+			"integrity": "sha512-yZkuWcTTfh5h/DrR4Q4QvJSARJdb6wjwn/sN0qKMYEkvwaVFek8YWfrgtL8oWaRdl0fLte0Y1wWMzLbwoaII1g==",
 			"dev": true,
 			"dependencies": {
 				"@semantic-release/commit-analyzer": "^12.0.0",
@@ -17990,7 +18019,7 @@
 				"micromatch": "^4.0.2",
 				"p-each-series": "^3.0.0",
 				"p-reduce": "^3.0.0",
-				"read-pkg-up": "^11.0.0",
+				"read-package-up": "^11.0.0",
 				"resolve-from": "^5.0.0",
 				"semver": "^7.3.2",
 				"semver-diff": "^4.0.0",
@@ -19556,9 +19585,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.4.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.4.tgz",
-			"integrity": "sha512-dGE2Vv8cpVvw28v8HCPqyb08EzbBURxDpuhJvTrusShUfGnhHBafDsLdS1EhhxyL6BJQE+2cT3dDPAv+MQ6oLw==",
+			"version": "5.4.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+			"integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "1.0.1",
 			"license": "mit",
 			"dependencies": {
-				"@beecode/msh-logger": "1.0.2"
+				"@beecode/msh-logger": "1.0.3"
 			},
 			"devDependencies": {
 				"@babel/cli": "7.24.1",
@@ -31,8 +31,8 @@
 				"@semantic-release/release-notes-generator": "13.0.0",
 				"@types/glob": "8.1.0",
 				"@types/node": "20.12.7",
-				"@typescript-eslint/eslint-plugin": "7.6.0",
-				"@typescript-eslint/parser": "7.6.0",
+				"@typescript-eslint/eslint-plugin": "7.7.0",
+				"@typescript-eslint/parser": "7.7.0",
 				"commitizen": "4.3.0",
 				"concurrently": "8.2.2",
 				"eslint": "8.57.0",
@@ -2076,11 +2076,11 @@
 			"dev": true
 		},
 		"node_modules/@beecode/msh-logger": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@beecode/msh-logger/-/msh-logger-1.0.2.tgz",
-			"integrity": "sha512-8s1DNyCQhNo79hrJPpTQxmMBoe+lIQ7pKKLhmnPyXaT7EiKqeSOr1u4U57ZmY23rNYkEZeF6FhPsNuleBOsnsg==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@beecode/msh-logger/-/msh-logger-1.0.3.tgz",
+			"integrity": "sha512-RQPrzAdV0vvDkWdHwM5PpOiP7bGboYJBNv37gOYG3wv3c8bP/5olO0xB7PyzjH+oxwEdyaQMGrRuyYXUO4sU/w==",
 			"dependencies": {
-				"@beecode/msh-util": "2.0.3"
+				"@beecode/msh-util": "2.0.5"
 			},
 			"engines": {
 				"node": ">=14",
@@ -2106,12 +2106,12 @@
 			}
 		},
 		"node_modules/@beecode/msh-util": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@beecode/msh-util/-/msh-util-2.0.3.tgz",
-			"integrity": "sha512-wRB6Cs4yDXeBXUjfwPxhdeXjGSSOVv+aiBPjuySE0V9f7KlGY6m7YyBbmXFCAUcAI8HKCHYNoJtuN9OhJ82PWg==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@beecode/msh-util/-/msh-util-2.0.5.tgz",
+			"integrity": "sha512-4tWuWT6i19F0F74zlfKPPQVoIooW42FR1BJp1a8mSKbONdOCj4f6flvhu3wJeb51mqfxAVfvZcP75vyGuQfgXQ==",
 			"dependencies": {
 				"date-fns": "3.6.0",
-				"date-fns-tz": "3.0.0",
+				"date-fns-tz": "3.0.1",
 				"joi": "17.12.3",
 				"lodash.clonedeep": "4.5.0",
 				"rxjs": "7.8.1"
@@ -2131,9 +2131,9 @@
 			}
 		},
 		"node_modules/@beecode/msh-util/node_modules/date-fns-tz": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.0.0.tgz",
-			"integrity": "sha512-YgRowJwvCAAjN1A5F2l1ZjnYKThX7YDq399qo+ThXFpeOqinN1u8SUqfM5IdRQSpai18Iy3EBMb6/CXTSnDstg==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.0.1.tgz",
+			"integrity": "sha512-LGKFMKEllm9tCirgYhha3rqfw5nstTULXnKKCk2qO/qju1rfxpUI9IXzmpOd5w727TtrfenAVafql0B/vs6aQQ==",
 			"dependencies": {
 				"lodash.clonedeep": "^4.5.0"
 			},
@@ -4529,16 +4529,16 @@
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.6.0.tgz",
-			"integrity": "sha512-gKmTNwZnblUdnTIJu3e9kmeRRzV2j1a/LUO27KNNAnIC5zjy1aSvXSRp4rVNlmAoHlQ7HzX42NbKpcSr4jF80A==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.7.0.tgz",
+			"integrity": "sha512-GJWR0YnfrKnsRoluVO3PRb9r5aMZriiMMM/RHj5nnTrBy1/wIgk76XCtCKcnXGjpZQJQRFtGV9/0JJ6n30uwpQ==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.10.0",
-				"@typescript-eslint/scope-manager": "7.6.0",
-				"@typescript-eslint/type-utils": "7.6.0",
-				"@typescript-eslint/utils": "7.6.0",
-				"@typescript-eslint/visitor-keys": "7.6.0",
+				"@typescript-eslint/scope-manager": "7.7.0",
+				"@typescript-eslint/type-utils": "7.7.0",
+				"@typescript-eslint/utils": "7.7.0",
+				"@typescript-eslint/visitor-keys": "7.7.0",
 				"debug": "^4.3.4",
 				"graphemer": "^1.4.0",
 				"ignore": "^5.3.1",
@@ -4564,15 +4564,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.6.0.tgz",
-			"integrity": "sha512-usPMPHcwX3ZoPWnBnhhorc14NJw9J4HpSXQX4urF2TPKG0au0XhJoZyX62fmvdHONUkmyUe74Hzm1//XA+BoYg==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.7.0.tgz",
+			"integrity": "sha512-fNcDm3wSwVM8QYL4HKVBggdIPAy9Q41vcvC/GtDobw3c4ndVT3K6cqudUmjHPw8EAp4ufax0o58/xvWaP2FmTg==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "7.6.0",
-				"@typescript-eslint/types": "7.6.0",
-				"@typescript-eslint/typescript-estree": "7.6.0",
-				"@typescript-eslint/visitor-keys": "7.6.0",
+				"@typescript-eslint/scope-manager": "7.7.0",
+				"@typescript-eslint/types": "7.7.0",
+				"@typescript-eslint/typescript-estree": "7.7.0",
+				"@typescript-eslint/visitor-keys": "7.7.0",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -4592,13 +4592,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.6.0.tgz",
-			"integrity": "sha512-ngttyfExA5PsHSx0rdFgnADMYQi+Zkeiv4/ZxGYUWd0nLs63Ha0ksmp8VMxAIC0wtCFxMos7Lt3PszJssG/E6w==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.7.0.tgz",
+			"integrity": "sha512-/8INDn0YLInbe9Wt7dK4cXLDYp0fNHP5xKLHvZl3mOT5X17rK/YShXaiNmorl+/U4VKCVIjJnx4Ri5b0y+HClw==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "7.6.0",
-				"@typescript-eslint/visitor-keys": "7.6.0"
+				"@typescript-eslint/types": "7.7.0",
+				"@typescript-eslint/visitor-keys": "7.7.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || >=20.0.0"
@@ -4609,13 +4609,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.6.0.tgz",
-			"integrity": "sha512-NxAfqAPNLG6LTmy7uZgpK8KcuiS2NZD/HlThPXQRGwz6u7MDBWRVliEEl1Gj6U7++kVJTpehkhZzCJLMK66Scw==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.7.0.tgz",
+			"integrity": "sha512-bOp3ejoRYrhAlnT/bozNQi3nio9tIgv3U5C0mVDdZC7cpcQEDZXvq8inrHYghLVwuNABRqrMW5tzAv88Vy77Sg==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "7.6.0",
-				"@typescript-eslint/utils": "7.6.0",
+				"@typescript-eslint/typescript-estree": "7.7.0",
+				"@typescript-eslint/utils": "7.7.0",
 				"debug": "^4.3.4",
 				"ts-api-utils": "^1.3.0"
 			},
@@ -4636,9 +4636,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.6.0.tgz",
-			"integrity": "sha512-h02rYQn8J+MureCvHVVzhl69/GAfQGPQZmOMjG1KfCl7o3HtMSlPaPUAPu6lLctXI5ySRGIYk94clD/AUMCUgQ==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.7.0.tgz",
+			"integrity": "sha512-G01YPZ1Bd2hn+KPpIbrAhEWOn5lQBrjxkzHkWvP6NucMXFtfXoevK82hzQdpfuQYuhkvFDeQYbzXCjR1z9Z03w==",
 			"dev": true,
 			"engines": {
 				"node": "^18.18.0 || >=20.0.0"
@@ -4649,13 +4649,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.6.0.tgz",
-			"integrity": "sha512-+7Y/GP9VuYibecrCQWSKgl3GvUM5cILRttpWtnAu8GNL9j11e4tbuGZmZjJ8ejnKYyBRb2ddGQ3rEFCq3QjMJw==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.7.0.tgz",
+			"integrity": "sha512-8p71HQPE6CbxIBy2kWHqM1KGrC07pk6RJn40n0DSc6bMOBBREZxSDJ+BmRzc8B5OdaMh1ty3mkuWRg4sCFiDQQ==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "7.6.0",
-				"@typescript-eslint/visitor-keys": "7.6.0",
+				"@typescript-eslint/types": "7.7.0",
+				"@typescript-eslint/visitor-keys": "7.7.0",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
@@ -4706,17 +4706,17 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.6.0.tgz",
-			"integrity": "sha512-x54gaSsRRI+Nwz59TXpCsr6harB98qjXYzsRxGqvA5Ue3kQH+FxS7FYU81g/omn22ML2pZJkisy6Q+ElK8pBCA==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.7.0.tgz",
+			"integrity": "sha512-LKGAXMPQs8U/zMRFXDZOzmMKgFv3COlxUQ+2NMPhbqgVm6R1w+nU1i4836Pmxu9jZAuIeyySNrN/6Rc657ggig==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.4.0",
 				"@types/json-schema": "^7.0.15",
 				"@types/semver": "^7.5.8",
-				"@typescript-eslint/scope-manager": "7.6.0",
-				"@typescript-eslint/types": "7.6.0",
-				"@typescript-eslint/typescript-estree": "7.6.0",
+				"@typescript-eslint/scope-manager": "7.7.0",
+				"@typescript-eslint/types": "7.7.0",
+				"@typescript-eslint/typescript-estree": "7.7.0",
 				"semver": "^7.6.0"
 			},
 			"engines": {
@@ -4731,12 +4731,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.6.0.tgz",
-			"integrity": "sha512-4eLB7t+LlNUmXzfOu1VAIAdkjbu5xNSerURS9X/S5TUKWFRpXRQZbmtPqgKmYx8bj3J0irtQXSiWAOY82v+cgw==",
+			"version": "7.7.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.7.0.tgz",
+			"integrity": "sha512-h0WHOj8MhdhY8YWkzIF30R379y0NqyOHExI9N9KCzvmu05EgG4FumeYa3ccfKUSphyWkWQE1ybVrgz/Pbam6YA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "7.6.0",
+				"@typescript-eslint/types": "7.7.0",
 				"eslint-visitor-keys": "^3.4.3"
 			},
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -137,9 +137,9 @@
 		"@babel/preset-env": "7.24.4",
 		"@babel/preset-typescript": "7.24.1",
 		"@beecode/msh-test-contractor": "0.3.9",
-		"@commitlint/cli": "19.2.1",
-		"@commitlint/config-conventional": "19.1.0",
-		"@commitlint/prompt": "19.2.0",
+		"@commitlint/cli": "19.2.2",
+		"@commitlint/config-conventional": "19.2.2",
+		"@commitlint/prompt": "19.2.2",
 		"@jest/globals": "29.7.0",
 		"@semantic-release/changelog": "6.0.3",
 		"@semantic-release/commit-analyzer": "12.0.0",
@@ -170,7 +170,7 @@
 		"markdown-toc": "1.2.0",
 		"prettier": "3.2.5",
 		"rimraf": "5.0.5",
-		"semantic-release": "23.0.7",
+		"semantic-release": "23.0.8",
 		"source-map-support": "0.5.21",
 		"ts-cleaner": "1.0.5",
 		"ts-jest": "29.1.2",
@@ -179,7 +179,7 @@
 		"tsc-watch": "6.2.0",
 		"typedoc": "0.25.13",
 		"typedoc-plugin-markdown": "3.17.1",
-		"typescript": "5.4.4"
+		"typescript": "5.4.5"
 	},
 	"engines": {
 		"node": ">=14",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
 		}
 	},
 	"dependencies": {
-		"@beecode/msh-logger": "1.0.2"
+		"@beecode/msh-logger": "1.0.3"
 	},
 	"devDependencies": {
 		"@babel/cli": "7.24.1",
@@ -149,8 +149,8 @@
 		"@semantic-release/release-notes-generator": "13.0.0",
 		"@types/glob": "8.1.0",
 		"@types/node": "20.12.7",
-		"@typescript-eslint/eslint-plugin": "7.6.0",
-		"@typescript-eslint/parser": "7.6.0",
+		"@typescript-eslint/eslint-plugin": "7.7.0",
+		"@typescript-eslint/parser": "7.7.0",
 		"commitizen": "4.3.0",
 		"concurrently": "8.2.2",
 		"eslint": "8.57.0",

--- a/src/app-starter.test.ts
+++ b/src/app-starter.test.ts
@@ -90,10 +90,10 @@ describe('AppStarter', () => {
 	})
 
 	describe('stop', () => {
-		it('should log end return if status is STOPPED', () => {
+		it('should log end return if status is STOPPED', async () => {
 			expect(appStarter['_status']).toEqual(AppStarterStatusMapper.STOPPED)
 
-			appStarter.stop()
+			await appStarter.stop()
 			expect(loggerMock().warn).toHaveBeenCalledTimes(1)
 			expect(loggerMock().warn).toHaveBeenCalledWith('App already stopped')
 		})


### PR DESCRIPTION
* fix: bump typescript from 5.4.4 to 5.4.5

Bumps [typescript](https://github.com/Microsoft/TypeScript) from 5.4.4 to 5.4.5.
- [Release notes](https://github.com/Microsoft/TypeScript/releases)
- [Changelog](https://github.com/microsoft/TypeScript/blob/main/azure-pipelines.release.yml)
- [Commits](microsoft/TypeScript@v5.4.4...v5.4.5)

---
updated-dependencies:
- dependency-name: typescript
  dependency-type: direct:development
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

* fix: bump @commitlint/prompt from 19.2.0 to 19.2.2

Bumps [@commitlint/prompt](https://github.com/conventional-changelog/commitlint/tree/HEAD/@commitlint/prompt) from 19.2.0 to 19.2.2.
- [Release notes](https://github.com/conventional-changelog/commitlint/releases)
- [Changelog](https://github.com/conventional-changelog/commitlint/blob/master/@commitlint/prompt/CHANGELOG.md)
- [Commits](https://github.com/conventional-changelog/commitlint/commits/v19.2.2/@commitlint/prompt)

---
updated-dependencies:
- dependency-name: "@commitlint/prompt"
  dependency-type: direct:development
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

* fix: bump @commitlint/cli from 19.2.1 to 19.2.2

Bumps [@commitlint/cli](https://github.com/conventional-changelog/commitlint/tree/HEAD/@commitlint/cli) from 19.2.1 to 19.2.2.
- [Release notes](https://github.com/conventional-changelog/commitlint/releases)
- [Changelog](https://github.com/conventional-changelog/commitlint/blob/master/@commitlint/cli/CHANGELOG.md)
- [Commits](https://github.com/conventional-changelog/commitlint/commits/v19.2.2/@commitlint/cli)

---
updated-dependencies:
- dependency-name: "@commitlint/cli"
  dependency-type: direct:development
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

* fix: bump semantic-release from 23.0.7 to 23.0.8

Bumps [semantic-release](https://github.com/semantic-release/semantic-release) from 23.0.7 to 23.0.8.
- [Release notes](https://github.com/semantic-release/semantic-release/releases)
- [Commits](semantic-release/semantic-release@v23.0.7...v23.0.8)

---
updated-dependencies:
- dependency-name: semantic-release
  dependency-type: direct:development
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

* fix: bump @commitlint/config-conventional from 19.1.0 to 19.2.2

Bumps [@commitlint/config-conventional](https://github.com/conventional-changelog/commitlint/tree/HEAD/@commitlint/config-conventional) from 19.1.0 to 19.2.2.
- [Release notes](https://github.com/conventional-changelog/commitlint/releases)
- [Changelog](https://github.com/conventional-changelog/commitlint/blob/master/@commitlint/config-conventional/CHANGELOG.md)
- [Commits](https://github.com/conventional-changelog/commitlint/commits/v19.2.2/@commitlint/config-conventional)

---
updated-dependencies:
- dependency-name: "@commitlint/config-conventional"
  dependency-type: direct:development
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>

---------

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>